### PR TITLE
Minor update if distributing SQCE file

### DIFF
--- a/Umbraco.gitignore
+++ b/Umbraco.gitignore
@@ -19,5 +19,9 @@
 !**/App_Data/[Pp]ackages/
 !**/[Uu]mbraco/[Dd]eveloper/[Pp]ackages
 
+# If you're using SQLCE and need to distribute the .sdf file either check 
+# that the extension is not already ignored or uncomment this next line:
+# !**/App_Data/[Uu]mbraco.sdf
+
 # ImageProcessor DiskCache 
 **/App_Data/cache/


### PR DESCRIPTION
**Reasons for making this change:**

in my instance, I have to send these to the client for their deployment procedure and needed to have this in a single location to reference at a later point.

**Links to documentation supporting these rule changes:** 

None

If this is a new template: 

N/A